### PR TITLE
fix: Decode the slug before the api call

### DIFF
--- a/index.js
+++ b/index.js
@@ -736,14 +736,18 @@ class Client {
   }
 
   getStories(params) {
+    if(params["tag-slugs"]) {
+      params["tag-slugs"] = decodeURIComponent(params["tag-slugs"])
+    }
     return this.request("/api/v1/stories", {
       qs: params
     })
   }
 
   getStoryBySlug(slug, params) {
+    const decodedSlug = decodeURIComponent(slug);
     return this.request("/api/v1/stories-by-slug", {
-      qs: _.merge({slug: slug}, params)
+      qs: _.merge({slug: decodedSlug}, params)
     }).catch(e => catch404(e, {}))
   }
 


### PR DESCRIPTION
1. The vernacular slugs were getting encoded by the browser.
2. This resulted in failed api call giving a 404.
3. This is to fix the vernacular slug issue for getting the story and getting the stories for vernacular tags.