### PR TITLE
feat(Custom Layout): support custom storylimit and custom nestedCollectionLimit 

### DIFF
--- a/collection-loader.js
+++ b/collection-loader.js
@@ -69,11 +69,16 @@ function updateItemsInPlace(
         []
       );
       collection.items = get(collectionSlugToCollection, [slugWithIndex, "items"], []);
-
       if (nestedCollectionLimit && collection.items) {
+        const customLayout = customLayouts[index];
         collection.items.forEach((item, index) => {
-          if (item.type === "collection" && nestedCollectionLimit[get(collection, ["associated-metadata", "layout"])]) {
+          if (
+            item.type === "collection" &&
+            (nestedCollectionLimit[customLayout] ||
+              nestedCollectionLimit[get(collection, ["associated-metadata", "layout"])])
+          ) {
             item.childCollectionLimit =
+              nestedCollectionLimit[customLayout][index] ||
               nestedCollectionLimit[get(collection, ["associated-metadata", "layout"])][index];
           }
         });

--- a/collection-loader.js
+++ b/collection-loader.js
@@ -7,12 +7,11 @@ function loadCollectionItems(
   { storyFields, storyLimits, defaultNestedLimit, customLayouts = [] }
 ) {
   const bulkRequestBody = collections.reduce((acc, collection, index) => {
-    let limit;
+    let limit = storyLimits[get(collection, ["associated-metadata", "layout"])];
     if (customLayouts[index]) {
       limit = storyLimits[customLayouts[index]];
-    } else {
-      limit = storyLimits[get(collection, ["associated-metadata", "layout"])];
     }
+
     if (!limit && get(collection, ["childCollectionLimit"])) {
       limit = get(collection, ["childCollectionLimit"]);
     }

--- a/collection-loader.js
+++ b/collection-loader.js
@@ -8,7 +8,7 @@ function loadCollectionItems(
 ) {
   const bulkRequestBody = collections.reduce((acc, collection, index) => {
     let limit;
-    if (customLayouts.length && customLayouts[index]) {
+    if (customLayouts[index]) {
       limit = storyLimits[customLayouts[index]];
     } else {
       limit = storyLimits[get(collection, ["associated-metadata", "layout"])];
@@ -72,14 +72,13 @@ function updateItemsInPlace(
       if (nestedCollectionLimit && collection.items) {
         const customLayout = customLayouts[index];
         collection.items.forEach((item, index) => {
-          if (
-            item.type === "collection" &&
-            (nestedCollectionLimit[customLayout] ||
-              nestedCollectionLimit[get(collection, ["associated-metadata", "layout"])])
-          ) {
-            item.childCollectionLimit =
-              nestedCollectionLimit[customLayout][index] ||
-              nestedCollectionLimit[get(collection, ["associated-metadata", "layout"])][index];
+          if (item.type === "collection") {
+            if (customLayout && nestedCollectionLimit[customLayout]) {
+              item.childCollectionLimit = nestedCollectionLimit[customLayout][index];
+            } else if (nestedCollectionLimit[get(collection, ["associated-metadata", "layout"])]) {
+              item.childCollectionLimit =
+                nestedCollectionLimit[get(collection, ["associated-metadata", "layout"])][index];
+            }
           }
         });
       }

--- a/collection-loader.spec.js
+++ b/collection-loader.spec.js
@@ -163,7 +163,7 @@ describe("Collection Loader", function() {
     expect(collectionDetails.items[0].items.length).toBe(1);
   });
 
-  it("should load child collection items w.r.t storylimit and nestedCollectionLimit when customlayouts is passed", async () => {
+  it("should load child collection items w.r.t storylimit and nestedCollectionLimit when customLayoutsStoryLimit is passed", async () => {
     const collection = {
       slug: "dumbledore-army",
       name: "Dumbledore Army",
@@ -205,10 +205,9 @@ describe("Collection Loader", function() {
     };
     let collectionData = await loadNestedCollectionData(client, collection, {
       depth: 2,
-      storyLimits: { ArrowOneColGrid: 1 },
       defaultNestedLimit: 1,
       nestedCollectionLimit: { ArrowOneColGrid: [1] },
-      customLayouts: ["ArrowOneColGrid"]
+      customLayoutsStoryLimit: [{ ArrowOneColGrid: 1 }]
     });
     expect(collectionData.items.length).toBe(1);
     expect(collectionData.items[0].items.length).toBe(1);

--- a/collection-loader.spec.js
+++ b/collection-loader.spec.js
@@ -162,4 +162,55 @@ describe("Collection Loader", function() {
     });
     expect(collectionDetails.items[0].items.length).toBe(1);
   });
+
+  it("should load child collection items w.r.t storylimit and nestedCollectionLimit when customlayouts is passed", async () => {
+    const collection = {
+      slug: "dumbledore-army",
+      name: "Dumbledore Army",
+      "data-source": "automated",
+      id: 147,
+      items: [
+        {
+          id: 147009,
+          type: "collection",
+          name: "Potter More",
+          slug: "potter-more"
+        }
+      ],
+      "collection-cache-keys": ["c/1088/147"]
+    };
+    let client = {
+      getInBulk: jest.fn().mockResolvedValue({
+        results: {
+          "potter-more-0": {
+            "updated-at": 1619675928521,
+            "collection-cache-keys": ["c/1088/147009", "e/1088/195845", "e/1088/198144"],
+            slug: "potter-more",
+            name: "potter more",
+            "data-source": "automated",
+            automated: true,
+            template: "default",
+            summary: "boy who lived",
+            id: 147009,
+            items: [
+              {
+                id: "353b4f32-5fae-4165-9b67-50e0c765789",
+                type: "story"
+              }
+            ],
+            "created-at": 1619029886576
+          }
+        }
+      })
+    };
+    let collectionData = await loadNestedCollectionData(client, collection, {
+      depth: 2,
+      storyLimits: { ArrowOneColGrid: 1 },
+      defaultNestedLimit: 1,
+      nestedCollectionLimit: { ArrowOneColGrid: [1] },
+      customLayouts: ["ArrowOneColGrid"]
+    });
+    expect(collectionData.items.length).toBe(1);
+    expect(collectionData.items[0].items.length).toBe(1);
+  });
 });

--- a/collection-loader.spec.js
+++ b/collection-loader.spec.js
@@ -163,7 +163,7 @@ describe("Collection Loader", function() {
     expect(collectionDetails.items[0].items.length).toBe(1);
   });
 
-  it("should load child collection items w.r.t storylimit and nestedCollectionLimit when customLayoutsStoryLimit is passed", async () => {
+  it("should load child collection items w.r.t storylimit and nestedCollectionLimit when customLayouts is passed", async () => {
     const collection = {
       slug: "dumbledore-army",
       name: "Dumbledore Army",
@@ -206,8 +206,7 @@ describe("Collection Loader", function() {
     let collectionData = await loadNestedCollectionData(client, collection, {
       depth: 2,
       defaultNestedLimit: 1,
-      nestedCollectionLimit: { ArrowOneColGrid: [1] },
-      customLayoutsStoryLimit: [{ ArrowOneColGrid: 1 }]
+      customLayouts: [{ layout: "ArrowOneColGrid", storyLimit: 1, nestedCollectionLimit: [1] }]
     });
     expect(collectionData.items.length).toBe(1);
     expect(collectionData.items[0].items.length).toBe(1);

--- a/collection.spec.js
+++ b/collection.spec.js
@@ -140,7 +140,7 @@ describe("Collection", function() {
       expect(homeCollectionData.collection.items[0].items[3].items.length).toBe(4);
     });
   });
-  describe("Returns Home Collection based on customLayouts", function() {
+  describe("Returns Home Collection based on customLayoutsStoryLimit", function() {
     it("Returns home-collection with custom-layout's storylimit", async function() {
       const homeCollectionData = await Collection.getCollectionBySlug(
         getClient(),
@@ -148,8 +148,7 @@ describe("Collection", function() {
         {},
         {
           depth: 1,
-          storyLimits: { ArrowThreeColGrid: 6 },
-          customLayouts: ["ArrowThreeColGrid"]
+          customLayoutsStoryLimit: [{ ArrowThreeColGrid: 6 }]
         }
       );
       expect(homeCollectionData.collection.items[0].items.length).toBe(6);
@@ -162,9 +161,8 @@ describe("Collection", function() {
         {
           depth: 1,
           collectionOfCollectionsIndexes: [0],
-          storyLimits: { ArrowFourColTwelveStories: 4 },
           nestedCollectionLimit: { ArrowFourColTwelveStories: [3, 3, 3] },
-          customLayouts: ["ArrowFourColTwelveStories"]
+          customLayoutsStoryLimit: [{ ArrowFourColTwelveStories: 4 }]
         }
       );
       expect(homeCollectionData.collection.items[0].items.length).toBe(4);

--- a/collection.spec.js
+++ b/collection.spec.js
@@ -140,4 +140,37 @@ describe("Collection", function() {
       expect(homeCollectionData.collection.items[0].items[3].items.length).toBe(4);
     });
   });
+  describe("Returns Home Collection based on customLayouts", function() {
+    it("Returns home-collection with custom-layout's storylimit", async function() {
+      const homeCollectionData = await Collection.getCollectionBySlug(
+        getClient(),
+        "home",
+        {},
+        {
+          depth: 1,
+          storyLimits: { ArrowThreeColGrid: 6 },
+          customLayouts: ["ArrowThreeColGrid"]
+        }
+      );
+      expect(homeCollectionData.collection.items[0].items.length).toBe(6);
+    });
+    it("Returns home-collection with custom-layout's nestedCollectionLimit", async function() {
+      const homeCollectionData = await Collection.getCollectionBySlug(
+        getClient(),
+        "home",
+        {},
+        {
+          depth: 1,
+          collectionOfCollectionsIndexes: [0],
+          storyLimits: { ArrowFourColTwelveStories: 4 },
+          nestedCollectionLimit: { ArrowFourColTwelveStories: [3, 3, 3] },
+          customLayouts: ["ArrowFourColTwelveStories"]
+        }
+      );
+      expect(homeCollectionData.collection.items[0].items.length).toBe(4);
+      expect(homeCollectionData.collection.items[0].items[0].items.length).toBe(3);
+      expect(homeCollectionData.collection.items[0].items[1].items.length).toBe(3);
+      expect(homeCollectionData.collection.items[0].items[2].items.length).toBe(3);
+    });
+  });
 });

--- a/collection.spec.js
+++ b/collection.spec.js
@@ -140,7 +140,7 @@ describe("Collection", function() {
       expect(homeCollectionData.collection.items[0].items[3].items.length).toBe(4);
     });
   });
-  describe("Returns Home Collection based on customLayoutsStoryLimit", function() {
+  describe("Returns Home Collection based on customLayouts", function() {
     it("Returns home-collection with custom-layout's storylimit", async function() {
       const homeCollectionData = await Collection.getCollectionBySlug(
         getClient(),
@@ -148,7 +148,7 @@ describe("Collection", function() {
         {},
         {
           depth: 1,
-          customLayoutsStoryLimit: [{ ArrowThreeColGrid: 6 }]
+          customLayouts: [{ layout: "ArrowThreeColGrid", storyLimit: 6 }]
         }
       );
       expect(homeCollectionData.collection.items[0].items.length).toBe(6);
@@ -161,8 +161,7 @@ describe("Collection", function() {
         {
           depth: 1,
           collectionOfCollectionsIndexes: [0],
-          nestedCollectionLimit: { ArrowFourColTwelveStories: [3, 3, 3] },
-          customLayoutsStoryLimit: [{ ArrowFourColTwelveStories: 4 }]
+          customLayouts: [{ layout: "ArrowFourColTwelveStories", storyLimit: 4, nestedCollectionLimit: [3, 3, 3] }]
         }
       );
       expect(homeCollectionData.collection.items[0].items.length).toBe(4);

--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ class Collection extends BaseAPI {
         - Movie `(Level 3)`
         - Song `(Level 3)`
     In the above example if we need to fetch the stories from `Sports Row` child collection we need to pass collectionOfCollectionsIndexes : [0], where 0 is the position of collection Sports Row and stories from Cricket and Football will be fetched
-   * @param {Object} options.customLayoutsStoryLimit It accepts an array of objects to fetch the customStoryLimit of custom layouts. (Ex: customLayoutsStoryLimit: [{"ArrowThreeColGrid" : 9}, {"ArrowFourColGrid" : 12}]).
+   * @param {Object} options.customLayouts It accepts an array of objects to fetch the custom storyLimit and custom nestedCollectionLimit of custom layouts. (Ex: customLayouts: [{layout: "ArrowThreeColGrid", storyLimit: 9}, {layout: "ArrowTwoColTenStories", storyLimit: 2, nestedCollectionLimit: [5,5]}]).
    * @return {(Promise<Collection|null>)}
    * @see {@link https://developers.quintype.com/swagger/#/collection/get_api_v1_collections__slug_ GET /api/v1/collections/:slug} API documentation for a list of parameters and fields
    */
@@ -315,7 +315,7 @@ class Collection extends BaseAPI {
       defaultNestedLimit = null,
       nestedCollectionLimit = {},
       collectionOfCollectionsIndexes = [],
-      customLayoutsStoryLimit = []
+      customLayouts = []
     } = options;
     const storyFields = _.get(params, ["story-fields"], DEFAULT_STORY_FIELDS);
 
@@ -336,7 +336,7 @@ class Collection extends BaseAPI {
             defaultNestedLimit,
             nestedCollectionLimit,
             collectionOfCollectionsIndexes,
-            customLayoutsStoryLimit
+            customLayouts
           })
         );
       })

--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ class Collection extends BaseAPI {
         - Movie `(Level 3)`
         - Song `(Level 3)`
     In the above example if we need to fetch the stories from `Sports Row` child collection we need to pass collectionOfCollectionsIndexes : [0], where 0 is the position of collection Sports Row and stories from Cricket and Football will be fetched
-   * @param {Object} options.customLayouts It accepts array of strings(layout names) to fetch the storylimit of custom layouts. (Ex: customLayouts: ["ArrowThreeColGrid", "ArrowFourColGrid"]).
+   * @param {Object} options.customLayoutsStoryLimit It accepts an array of objects to fetch the customStoryLimit of custom layouts. (Ex: customLayoutsStoryLimit: [{"ArrowThreeColGrid" : 9}, {"ArrowFourColGrid" : 12}]).
    * @return {(Promise<Collection|null>)}
    * @see {@link https://developers.quintype.com/swagger/#/collection/get_api_v1_collections__slug_ GET /api/v1/collections/:slug} API documentation for a list of parameters and fields
    */
@@ -315,7 +315,7 @@ class Collection extends BaseAPI {
       defaultNestedLimit = null,
       nestedCollectionLimit = {},
       collectionOfCollectionsIndexes = [],
-      customLayouts = []
+      customLayoutsStoryLimit = []
     } = options;
     const storyFields = _.get(params, ["story-fields"], DEFAULT_STORY_FIELDS);
 
@@ -336,7 +336,7 @@ class Collection extends BaseAPI {
             defaultNestedLimit,
             nestedCollectionLimit,
             collectionOfCollectionsIndexes,
-            customLayouts
+            customLayoutsStoryLimit
           })
         );
       })

--- a/index.js
+++ b/index.js
@@ -313,7 +313,8 @@ class Collection extends BaseAPI {
       storyLimits = {},
       defaultNestedLimit = null,
       nestedCollectionLimit = {},
-      collectionOfCollectionsIndexes = []
+      collectionOfCollectionsIndexes = [],
+      customLayouts = []
     } = options;
     const storyFields = _.get(params, ["story-fields"], DEFAULT_STORY_FIELDS);
 
@@ -333,7 +334,8 @@ class Collection extends BaseAPI {
             storyLimits,
             defaultNestedLimit,
             nestedCollectionLimit,
-            collectionOfCollectionsIndexes
+            collectionOfCollectionsIndexes,
+            customLayouts
           })
         );
       })

--- a/index.js
+++ b/index.js
@@ -304,6 +304,7 @@ class Collection extends BaseAPI {
         - Movie `(Level 3)`
         - Song `(Level 3)`
     In the above example if we need to fetch the stories from `Sports Row` child collection we need to pass collectionOfCollectionsIndexes : [0], where 0 is the position of collection Sports Row and stories from Cricket and Football will be fetched
+   * @param {Object} options.customLayouts It accepts array of strings(layout names) to fetch the storylimit of custom layouts. (Ex: customLayouts: ["ArrowThreeColGrid", "ArrowFourColGrid"]).
    * @return {(Promise<Collection|null>)}
    * @see {@link https://developers.quintype.com/swagger/#/collection/get_api_v1_collections__slug_ GET /api/v1/collections/:slug} API documentation for a list of parameters and fields
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.1-custom-story-limit.1",
+  "version": "2.1.1-custom-story-limit.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.0",
+  "version": "2.1.1-custom-story-limit.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.1-custom-story-limit.2",
+  "version": "2.1.1-custom-story-limit.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.1-custom-story-limit.0",
+  "version": "2.1.1-custom-story-limit.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.1-custom-story-limit.0",
+  "version": "2.1.1-custom-story-limit.1",
   "description": "client for accessing quintype API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.1-custom-story-limit.2",
+  "version": "2.1.1-custom-story-limit.3",
   "description": "client for accessing quintype API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.1-custom-story-limit.1",
+  "version": "2.1.1-custom-story-limit.2",
   "description": "client for accessing quintype API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.1.0",
+  "version": "2.1.1-custom-story-limit.0",
   "description": "client for accessing quintype API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Description: Currently we are supporting the storylimit and nestedCollectionlimit only for the layouts coming from bold. so have added a prop to support custom storylimit and custom nestedCollectionlimit for customLayouts

Fixes https://github.com/quintype/madrid/issues/4039, https://github.com/quintype/madrid/issues/4056

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
