### PR TITLE
Handling null SectionId issue for relatedStoriesApi 

### DIFF
--- a/index.js
+++ b/index.js
@@ -956,7 +956,7 @@ class Client {
 
   getRelatedStories(storyId = null, sectionId = null, params = {}) {
     return this.request("/api/v1/stories/" + storyId + "/related-stories", {
-      qs: { "section-id": sectionId, ...params }
+      qs: sectionId ? ({"section-id": sectionId, ...params }) : params
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -956,7 +956,7 @@ class Client {
 
   getRelatedStories(storyId = null, sectionId = null, params = {}) {
     return this.request("/api/v1/stories/" + storyId + "/related-stories", {
-      qs: sectionId ? ({"section-id": sectionId, ...params }) : params
+      qs: { ...(sectionId && {"section-id": sectionId}), ...params }
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/backend",
-  "version": "2.3.2",
+  "version": "2.3.3-section-null-issue.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/backend",
-      "version": "2.3.2",
+      "version": "2.3.3-section-null-issue.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/backend",
-  "version": "2.3.3-section-null-issue.0",
+  "version": "2.3.3-section-null-issue.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/backend",
-      "version": "2.3.3-section-null-issue.0",
+      "version": "2.3.3-section-null-issue.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.3.3-section-null-issue.0",
+  "version": "2.3.3-section-null-issue.1",
   "description": "client for accessing quintype API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/backend",
-  "version": "2.3.2",
+  "version": "2.3.3-section-null-issue.0",
   "description": "client for accessing quintype API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Description
While testing the `relativePath for src attribute => amp-next-page is disallowed ` issue , we faced 
nullpointerException for getRelatedStories API on malibu Staging when we passed infiniteScroll> source : "relatedStoriesApi"
 ( reason =>  queryParam issue => section-id=&limit=5 )


Fixes # (issue-reference)

https://github.com/quintype/ace-planning/issues/678

